### PR TITLE
Serve resources from blorb file

### DIFF
--- a/README
+++ b/README
@@ -57,6 +57,9 @@ RemGlk docs: http://eblong.com/zarf/glk/remglk/docs.html
 directly from the local file system. This does not work, because modern
 browsers will not allow an http: web page to load file: image URLs.)
 
+Alternatively just use --game option:
+python remote-if.py --debug --command=glulxer --game=sensory.blb
+
 This is a demo, *not* a production-ready solution.
 
 - This has no database component, nor any other sort of persistence.

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env -S bash -c "echo 'Please use \"source init.sh\" instead' >&2; exit 1"
+
+if declare -F deactivate >/dev/null; then
+	deactivate
+fi
+
+if [[ "${dirname:-}" == "" ]]; then
+	dirname="."
+fi
+
+if ! pip show virtualenv >&/dev/null; then
+	python -m pip install --user virtualenv
+fi
+python -m virtualenv "${dirname}/venv"
+source "${dirname}/venv/bin/activate"
+
+pip install -r "${dirname}/requirements.txt"
+
+site_packages="$(python -c 'import site; print(site.getsitepackages()[-1])')"
+if [[ ! -f "${site_packages}/blorbtool.py" ]]; then
+	ln -sv "$(realpath "${dirname}/../glk-dev/blorbtool.py")" "${site_packages}"
+fi


### PR DESCRIPTION
Add `--game` option to serve Blorb file resources using `blorbtool.py` as a library.

Requires https://github.com/erkyrath/glk-dev/pull/19.