### PR TITLE
Use manual virtual keyboard policy

### DIFF
--- a/static/glkote.js
+++ b/static/glkote.js
@@ -1480,6 +1480,8 @@ function accept_inputset(arg) {
             inputel.attr({
                 'aria-live': 'off',
                 'autocapitalize': 'off',
+                'virtualkeyboardpolicy': 'manual',
+                'onclick': 'navigator.virtualKeyboard?.show()',
             });
             if (argi.type == 'line') {
                 inputel.on('keypress', evhan_input_keypress);


### PR DESCRIPTION
Stops mobile virtual keyboard from flickering on each command.